### PR TITLE
chore: use loglevel "warn"

### DIFF
--- a/__tests__/e2e/configs/wdio.shared.conf.ts
+++ b/__tests__/e2e/configs/wdio.shared.conf.ts
@@ -19,7 +19,7 @@ export const config: MobileConfig = {
   // Test Configurations
   // ===================
   //
-  logLevel: 'silent',
+  logLevel: 'warn',
   bail: 0,
   baseUrl: 'http://localhost',
   waitforTimeout: 15000,


### PR DESCRIPTION
having the logs silenced is pretty bad for debugging (the tests were failing for me, without any debugging output)


thanks