### PR TITLE
feat: add storing data between closing and opening sessions

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -141,7 +141,7 @@ android {
         applicationId "com.saucelabs.mydemoapp.rn"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 240
+        versionCode 242
         versionName "1.2.1"
         // For the QR-code scanner
         missingDimensionStrategy 'react-native-camera', 'general'

--- a/ios/MyRNDemoApp/Info.plist
+++ b/ios/MyRNDemoApp/Info.plist
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>157</string>
+	<string>160</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true />
 	<key>NSAppTransportSecurity</key>

--- a/ios/MyRNDemoAppTests/Info.plist
+++ b/ios/MyRNDemoAppTests/Info.plist
@@ -19,6 +19,6 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>157</string>
+	<string>160</string>
 </dict>
 </plist>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -371,6 +371,8 @@ PODS:
     - React-Core
   - RNBootSplash (4.0.2):
     - React-Core
+  - RNCAsyncStorage (1.17.3):
+    - React-Core
   - RNCMaskedView (0.1.11):
     - React
   - RNFS (2.18.0):
@@ -485,6 +487,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - rn-fetch-blob (from `../node_modules/rn-fetch-blob`)
   - RNBootSplash (from `../node_modules/react-native-bootsplash`)
+  - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
   - RNFS (from `../node_modules/react-native-fs`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
@@ -598,6 +601,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/rn-fetch-blob"
   RNBootSplash:
     :path: "../node_modules/react-native-bootsplash"
+  RNCAsyncStorage:
+    :path: "../node_modules/@react-native-async-storage/async-storage"
   RNCMaskedView:
     :path: "../node_modules/@react-native-community/masked-view"
   RNFS:
@@ -673,6 +678,7 @@ SPEC CHECKSUMS:
   ReactCommon: 57b69f6383eafcbd7da625bfa6003810332313c4
   rn-fetch-blob: f065bb7ab7fb48dd002629f8bdcb0336602d3cba
   RNBootSplash: 5e82ba24a59a07315cbb2bb4855bb8d76fc7e802
+  RNCAsyncStorage: 005c0e2f09575360f142d0d1f1f15e4ec575b1af
   RNCMaskedView: 0e1bc4bfa8365eba5fbbb71e07fbdc0555249489
   RNFS: 3ab21fa6c56d65566d1fb26c2228e2b6132e5e32
   RNGestureHandler: e5c7cab5f214503dcefd6b2b0cefb050e1f51c4a

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "version.apps": "npx react-native-version --never-amend"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "^1.17.3",
     "@react-native-community/cameraroll": "^4.1.2",
     "@react-native-community/masked-view": "^0.1.11",
     "@react-navigation/bottom-tabs": "^6.0.9",

--- a/src/containers/CheckoutCompletePage.tsx
+++ b/src/containers/CheckoutCompletePage.tsx
@@ -1,4 +1,4 @@
-import React, {useContext} from 'react';
+import React from 'react';
 import {Image, ScrollView, StyleSheet, Text, View} from 'react-native';
 import {CommonActions} from '@react-navigation/native';
 import {ROUTES} from '../navigation/Routes';
@@ -7,10 +7,6 @@ import {CartStackParamList} from '../navigation/types';
 import {Colors} from '../styles/Colors';
 import {MUSEO_SANS_300, MUSEO_SANS_700} from '../utils/Constants';
 import Button from '../components/Button';
-import {StoreContext} from '../store/Store';
-import {resetCart} from '../store/actions/CartActions';
-import {resetCardDetails} from '../store/actions/CardDetailsActions';
-import {resetShippingAddress} from '../store/actions/ShippingAddressActions';
 import I18n from '../config/I18n';
 import {testProperties} from '../config/TestProperties';
 
@@ -19,12 +15,7 @@ type CheckoutCompleteProps = {
 };
 
 const CheckoutCompletePage = ({navigation}: CheckoutCompleteProps) => {
-  const {dispatch} = useContext(StoreContext);
-
   const continueShopping = () => {
-    dispatch(resetCart());
-    dispatch(resetCardDetails());
-    dispatch(resetShippingAddress());
     navigation.dispatch({
       ...CommonActions.reset({
         index: 0,

--- a/src/containers/CheckoutReviewOrderPage.tsx
+++ b/src/containers/CheckoutReviewOrderPage.tsx
@@ -13,10 +13,16 @@ import Footer from '../components/Footer';
 import I18n from '../config/I18n';
 import {testProperties} from '../config/TestProperties';
 import {parseDeepLinkProductData} from '../utils/DeepLinking';
-import {addProductToCart} from '../store/actions/CartActions';
+import {addProductToCart, resetCart} from '../store/actions/CartActions';
 import {RouteProp} from '@react-navigation/native';
-import {updateShippingAddress} from '../store/actions/ShippingAddressActions';
-import {updateCardDetails} from '../store/actions/CardDetailsActions';
+import {
+  resetShippingAddress,
+  updateShippingAddress,
+} from '../store/actions/ShippingAddressActions';
+import {
+  resetCardDetails,
+  updateCardDetails,
+} from '../store/actions/CardDetailsActions';
 
 type CheckoutReviewOrderProps = {
   navigation: StackNavigationProp<CartStackParamList, ROUTES.CHECKOUT_COMPLETE>;
@@ -38,6 +44,12 @@ const CheckoutReviewOrderPage = ({
   } = useContext(StoreContext);
   const deliveryCosts = 5.99;
   const totalCosts = cartContent.totalPrice + deliveryCosts;
+  const navigateToCheckoutComplete = () => {
+    dispatch(resetCart());
+    dispatch(resetCardDetails());
+    dispatch(resetShippingAddress());
+    navigation.navigate(ROUTES.CHECKOUT_COMPLETE);
+  };
 
   useEffect(() => {
     // @ts-ignore
@@ -193,7 +205,7 @@ const CheckoutReviewOrderPage = ({
         <Footer />
       </ScrollView>
       <CheckoutFooter
-        onPress={() => navigation.navigate(ROUTES.CHECKOUT_COMPLETE)}
+        onPress={navigateToCheckoutComplete}
         title={I18n.t('checkoutReviewOrder.submitButtonText')}
         totalNumber={cartContent.totalAmount}
         totalPrice={totalCosts}

--- a/src/navigation/DrawerNavigation.tsx
+++ b/src/navigation/DrawerNavigation.tsx
@@ -15,13 +15,10 @@ import {
 import TestFairy from 'react-native-testfairy';
 import {Colors} from '../styles/Colors';
 import {ROUTES} from './Routes';
-import {StoreContext} from '../store/Store';
-import {enableBiometrics, logout} from '../store/actions/AuthenticationActions';
+import {resetStore, StoreContext} from '../store/Store';
+import {logout} from '../store/actions/AuthenticationActions';
 import {IS_IOS, MUSEO_SANS_300} from '../utils/Constants';
 import {DrawerActions} from '@react-navigation/native';
-import {resetCart} from '../store/actions/CartActions';
-import {resetCardDetails} from '../store/actions/CardDetailsActions';
-import {resetShippingAddress} from '../store/actions/ShippingAddressActions';
 import I18n from '../config/I18n';
 import {testProperties} from '../config/TestProperties';
 import {getBiometricsLabel} from '../containers/Biometrics';
@@ -80,11 +77,8 @@ const DrawerContent: FC<DrawerContentComponentProps> = ({navigation}) => {
         },
         {
           text: I18n.t('drawer.reset.ok'),
-          onPress: () => {
-            dispatch(resetCart());
-            dispatch(resetCardDetails());
-            dispatch(resetShippingAddress());
-            dispatch(enableBiometrics(false));
+          onPress: async () => {
+            await resetStore(dispatch);
             Alert.alert(I18n.t('drawer.reset.resetSuccessful'));
           },
         },

--- a/src/store/actions/AuthenticationActions.ts
+++ b/src/store/actions/AuthenticationActions.ts
@@ -7,6 +7,7 @@ enum AuthenticationActionEnum {
   LOGOUT = 'LOGOUT',
   UPDATE_BIOMETRICS = 'UPDATE_BIOMETRICS',
   ENABLE_BIOMETRICS = 'ENABLE_BIOMETRICS',
+  INITIAL_STATE = 'INITIAL_STATE',
 }
 
 export type AuthenticationActionType =
@@ -17,6 +18,9 @@ export type AuthenticationActionType =
     }
   | {
       type: AuthenticationActionEnum.LOGOUT;
+    }
+  | {
+      type: AuthenticationActionEnum.INITIAL_STATE;
     }
   | {
       isBiometricsAvailable: boolean;
@@ -39,6 +43,11 @@ function login(username: string) {
 function logout() {
   return {
     type: AuthenticationActionEnum.LOGOUT,
+  };
+}
+function setInitialAuthenticationState() {
+  return {
+    type: AuthenticationActionEnum.INITIAL_STATE,
   };
 }
 
@@ -88,5 +97,6 @@ export {
   getBiometricsData,
   login,
   logout,
+  setInitialAuthenticationState,
   updateBiometricSettings,
 };

--- a/src/store/actions/CartActions.ts
+++ b/src/store/actions/CartActions.ts
@@ -1,10 +1,11 @@
-import {CartItemInterface} from '../reducers/CartReducer';
+import {CartItemInterface, CartState} from '../reducers/CartReducer';
 
 enum CartActionEnum {
   ADD_TO_CART = 'ADD_TO_CART',
   REMOVE_FROM_CART = 'REMOVE_FROM_CART',
   DELETE_FROM_CART = 'DELETE_FROM_CART',
   RESET_CART = 'RESET_CART',
+  SET_INITIAL_CART_STATE = 'SET_INITIAL_CART_STATE',
 }
 
 export type CartActionType =
@@ -22,6 +23,10 @@ export type CartActionType =
     }
   | {
       type: CartActionEnum.RESET_CART;
+    }
+  | {
+      initialCartState: CartItemInterface[];
+      type: CartActionEnum.SET_INITIAL_CART_STATE;
     };
 
 /**
@@ -55,6 +60,16 @@ function deleteProductFromCart(selectedProduct: CartItemInterface) {
 }
 
 /**
+ * Set initial cart state
+ */
+function setInitialCartState(initialCartState: CartState) {
+  return {
+    initialCartState,
+    type: CartActionEnum.SET_INITIAL_CART_STATE,
+  };
+}
+
+/**
  * Reset cart
  */
 function resetCart() {
@@ -69,4 +84,5 @@ export {
   removeProductFromCart,
   deleteProductFromCart,
   resetCart,
+  setInitialCartState,
 };

--- a/src/store/actions/ProductStoreActions.ts
+++ b/src/store/actions/ProductStoreActions.ts
@@ -1,4 +1,3 @@
-import {ItemInterface} from '../../data/inventoryData';
 import {ProductStoreInterface} from '../reducers/ProductStoreReducer';
 import {SortOptionType} from '../../utils/Sorting';
 
@@ -24,7 +23,7 @@ export type ProductStoreActionType =
 /**
  * Update the complete product store
  */
-function updateProductStore(products: ItemInterface[]) {
+function updateProductStore(products: ProductStoreInterface) {
   return {
     products,
     type: ProductStoreActionEnum.UPDATE_STORE,

--- a/src/store/reducers/AuthenticationReducer.ts
+++ b/src/store/reducers/AuthenticationReducer.ts
@@ -40,6 +40,9 @@ const authenticationReducer = (
         username: '',
       };
     }
+    case ACTIONS.INITIAL_STATE: {
+      return initialAuthenticationState;
+    }
     case ACTIONS.UPDATE_BIOMETRICS: {
       return {
         ...state,

--- a/src/store/reducers/CardDetailsReducer.ts
+++ b/src/store/reducers/CardDetailsReducer.ts
@@ -2,6 +2,7 @@ import {
   CardActionEnum as ACTIONS,
   CardDetailsActionType,
 } from '../actions/CardDetailsActions';
+import {StateNameEnum, storeAsyncData} from '../Store';
 
 export interface CardDetailsInterface {
   cardFullName: string;
@@ -36,19 +37,23 @@ const initialCardDetailsState: CardDetailsInterface = {
     country: '',
   },
 };
-
 const cardDetailsReducer = (
   state = initialCardDetailsState,
   action: CardDetailsActionType,
 ) => {
   switch (action.type) {
     case ACTIONS.UPDATE_CARD_DETAILS: {
-      return {
+      const newState = {
         ...state,
         ...action.cardDetails,
       };
+      storeAsyncData(StateNameEnum.CARD_DETAILS, newState);
+
+      return newState;
     }
     case ACTIONS.RESET_CARD_DETAILS: {
+      storeAsyncData(StateNameEnum.CARD_DETAILS, initialCardDetailsState);
+
       return initialCardDetailsState;
     }
     default:

--- a/src/store/reducers/CartReducer.ts
+++ b/src/store/reducers/CartReducer.ts
@@ -3,6 +3,7 @@ import {
   CartActionType,
 } from '../actions/CartActions';
 import {ITEM_COLOR_TYPE, ItemInterface} from '../../data/inventoryData';
+import {StateNameEnum, storeAsyncData} from '../Store';
 
 export interface ItemIdentifierInterface {
   color: ITEM_COLOR_TYPE;
@@ -52,8 +53,7 @@ const cartReducer = (state = initialCartState, action: CartActionType) => {
 
         return item;
       });
-
-      return {
+      const newState = {
         ...state,
         items: added ? updatedItems : updatedItems.concat(selectedProduct),
         totalAmount: added ? totalAmount : totalAmount + selectedProduct.amount,
@@ -61,6 +61,9 @@ const cartReducer = (state = initialCartState, action: CartActionType) => {
           ? totalPrice
           : totalPrice + selectedProduct.amount * selectedProduct.price,
       };
+      storeAsyncData(StateNameEnum.CART_CONTENT, newState);
+
+      return newState;
     }
     case ACTIONS.REMOVE_FROM_CART: {
       const {
@@ -85,8 +88,7 @@ const cartReducer = (state = initialCartState, action: CartActionType) => {
 
         return item;
       });
-
-      return {
+      const newState = {
         ...state,
         items: removed
           ? updatedItems
@@ -96,6 +98,9 @@ const cartReducer = (state = initialCartState, action: CartActionType) => {
         totalAmount: removed ? totalAmount : totalAmount - amount,
         totalPrice: removed ? totalPrice : totalPrice - amount * price,
       };
+      storeAsyncData(StateNameEnum.CART_CONTENT, newState);
+
+      return newState;
     }
     case ACTIONS.DELETE_FROM_CART: {
       const {
@@ -103,7 +108,7 @@ const cartReducer = (state = initialCartState, action: CartActionType) => {
       } = action;
       const {totalAmount, totalPrice} = state;
 
-      return {
+      const newState = {
         ...state,
         items: state.items.filter(
           item => !(item.id === id && item.selectedColor === selectedColor),
@@ -111,9 +116,19 @@ const cartReducer = (state = initialCartState, action: CartActionType) => {
         totalAmount: totalAmount - amount,
         totalPrice: totalPrice - price * amount,
       };
+      storeAsyncData(StateNameEnum.CART_CONTENT, newState);
+
+      return newState;
     }
     case ACTIONS.RESET_CART:
+      storeAsyncData(StateNameEnum.CART_CONTENT, initialCartState);
+
       return initialCartState;
+    case ACTIONS.SET_INITIAL_CART_STATE:
+      return {
+        ...state,
+        ...action.initialCartState,
+      };
     default:
       return state;
   }

--- a/src/store/reducers/ProductStoreReducer.ts
+++ b/src/store/reducers/ProductStoreReducer.ts
@@ -4,6 +4,7 @@ import {
 } from '../actions/ProductStoreActions';
 import {ItemInterface, StoreData} from '../../data/inventoryData';
 import {SORT_OPTIONS, SortOptionType, sortStoreData} from '../../utils/Sorting';
+import {StateNameEnum, storeAsyncData} from '../Store';
 
 export interface ProductStoreInterface {
   items: ItemInterface[];
@@ -22,15 +23,18 @@ const productStoreReducer = (
 ) => {
   switch (action.type) {
     case ACTIONS.UPDATE_STORE: {
-      return state;
+      return action.products;
     }
     case ACTIONS.UPDATE_SORTING: {
-      return {
+      const newState = {
         ...state,
         items: sortStoreData(state.items, action.sortOption),
         sortModalVisible: !state.sortModalVisible,
         sortState: action.sortOption,
       };
+      storeAsyncData(StateNameEnum.PRODUCTS, newState);
+
+      return newState;
     }
     case ACTIONS.TOGGLE_SORT_MODAL: {
       return {

--- a/src/store/reducers/ShippingAddressReducer.ts
+++ b/src/store/reducers/ShippingAddressReducer.ts
@@ -2,6 +2,7 @@ import {
   ShippingAddressActionEnum as ACTIONS,
   ShippingAddressActionType,
 } from '../actions/ShippingAddressActions';
+import {StateNameEnum, storeAsyncData} from '../Store';
 
 export interface ShippingAddressInterface {
   fullName: string;
@@ -22,19 +23,26 @@ const initialShippingAddressState: ShippingAddressInterface = {
   zipCode: '',
   country: '',
 };
-
 const shippingAddressReducer = (
   state = initialShippingAddressState,
   action: ShippingAddressActionType,
 ) => {
   switch (action.type) {
     case ACTIONS.UPDATE_SHIPPING_ADDRESS: {
-      return {
+      const newState = {
         ...state,
         ...action.shippingAddress,
       };
+      storeAsyncData(StateNameEnum.SHIPPING_ADDRESS, newState);
+
+      return newState;
     }
     case ACTIONS.RESET_SHIPPING_ADDRESS: {
+      storeAsyncData(
+        StateNameEnum.SHIPPING_ADDRESS,
+        initialShippingAddressState,
+      );
+
       return initialShippingAddressState;
     }
     default:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1804,6 +1804,13 @@
   dependencies:
     merge-options "^3.0.4"
 
+"@react-native-async-storage/async-storage@^1.17.3":
+  version "1.17.3"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.17.3.tgz#fa7010aa9b6a811ff653df3698a90d3c173dd6a6"
+  integrity sha512-2dxdlGwBjBP2qYu6F72U7cRRFshISYiNEWCaQNOJtxUERCMaYRWcniYqhL248KSbGUMpRhFCEtliztsiGoYYMA==
+  dependencies:
+    merge-options "^3.0.4"
+
 "@react-native-community/cameraroll@^4.1.2":
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/@react-native-community/cameraroll/-/cameraroll-4.1.2.tgz#489c6bb6137571540d93c543d5fcf8c652b548ec"


### PR DESCRIPTION
This PR adds storing data to the local storage. This means that preferences like selected products and so on are shown again when you've killed the app and re-opened it again